### PR TITLE
web-server/06-sockets is missing a test.txt file 

### DIFF
--- a/web-server/06-sockets/test.txt
+++ b/web-server/06-sockets/test.txt
@@ -1,0 +1,1 @@
+Nitinat Plain Text Page


### PR DESCRIPTION
The telnet example in web-server/06-sockets mentions a 'test.txt' file that does not exist.

From the file:

> -   `python telnet-server.py 8080` in one window, `python telnet-client.py 8080 < test.txt` in another.
