### PR TITLE
Crawler's requests need "Host: xkcd.com" header.

### DIFF
--- a/crawler/chapter.md
+++ b/crawler/chapter.md
@@ -20,7 +20,7 @@ How do we make the crawler concurrent? Traditionally we would create a thread po
 def fetch(url):
     sock = socket.socket()
     sock.connect(('xkcd.com', 80))
-    request = 'GET {} HTTP/1.0\r\n\r\n'.format(url)
+    request = 'GET {} HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'.format(url)
     sock.send(request.encode('ascii'))
     response = b''
     chunk = sock.recv(4096)
@@ -63,7 +63,7 @@ Irritatingly, a non-blocking socket throws an exception from `connect`, even whe
 Now our crawler needs a way to know when the connection is established, so it can send the HTTP request. We could simply keep trying in a tight loop:
 
 ```python
-request = 'GET {} HTTP/1.0\r\n\r\n'.format(url)
+request = 'GET {} HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'.format(url)
 encoded = request.encode('ascii')
 
 while True:
@@ -188,7 +188,7 @@ Here is the implementation of `connected`:
     def connected(self, key, mask):
         print('connected!')
         selector.unregister(key.fd)
-        request = 'GET {} HTTP/1.0\r\n\r\n'.format(self.url)
+        request = 'GET {} HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'.format(url)
         self.sock.send(request.encode('ascii'))
         
         # Register the next callback.
@@ -254,7 +254,7 @@ Let us explain what we mean by that. Consider how simply we fetched a URL on a t
 def fetch(url):
     sock = socket.socket()
     sock.connect(('xkcd.com', 80))
-    request = 'GET {} HTTP/1.0\r\n\r\n'.format(url)
+    request = 'GET {} HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'.format(url)
     sock.send(request.encode('ascii'))
     response = b''
     chunk = sock.recv(4096)

--- a/crawler/supplemental/blocking-fetch.py
+++ b/crawler/supplemental/blocking-fetch.py
@@ -1,10 +1,10 @@
 import socket
 
 
-def threaded_method(self):
+def threaded_method():
     sock = socket.socket()
     sock.connect(('xkcd.com', 80))
-    request = 'GET {} HTTP/1.0\r\n\r\n'.format('/353/')
+    request = 'GET /353/ HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'
     sock.send(request.encode('ascii'))
     response = b''
     chunk = sock.recv(4096)
@@ -12,5 +12,6 @@ def threaded_method(self):
         response += chunk
         chunk = sock.recv(4096)
 
-
     print(response)
+
+threaded_method()

--- a/crawler/supplemental/loop-with-callbacks.py
+++ b/crawler/supplemental/loop-with-callbacks.py
@@ -36,8 +36,8 @@ class Fetcher:
 
     def connected(self, key, mask):
         selector.unregister(key.fd)
-        self.sock.send(
-            'GET {} HTTP/1.0\r\n\r\n'.format(self.url).encode('ascii'))
+        get = 'GET {} HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'.format(self.url)
+        self.sock.send(get.encode('ascii'))
         selector.register(key.fd, EVENT_READ, self.read_response)
 
     def read_response(self, key, mask):

--- a/crawler/supplemental/loop-with-coroutines.py
+++ b/crawler/supplemental/loop-with-coroutines.py
@@ -106,7 +106,8 @@ class Fetcher:
 
         sock = socket.socket()
         yield from connect(sock, ('xkcd.com', 80))
-        sock.send('GET {} HTTP/1.0\r\n\r\n'.format(self.url).encode('ascii'))
+        get = 'GET {} HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'.format(self.url)
+        sock.send(get.encode('ascii'))
         self.response = yield from read_all(sock)
 
         self._process_response()

--- a/crawler/supplemental/non-blocking-fetch-stupid.py
+++ b/crawler/supplemental/non-blocking-fetch-stupid.py
@@ -8,7 +8,7 @@ try:
 except BlockingIOError:
     pass
 
-request = 'GET {} HTTP/1.0\r\n\r\n'.format('/353/')
+request = 'GET /353/ HTTP/1.0\r\nHost: xkcd.com\r\n\r\n'
 encoded = request.encode('ascii')
 
 while True:


### PR DESCRIPTION
Crawler's requests need "Host: xkcd.com" header.

Looks like XKCD recently installed or reconfigured Varnish, even
HTTP 1.0 requests require the host is specified to make the examples
work.