### PR TITLE
[catechism]move raise logic to matcher constructors 

### DIFF
--- a/catechism/lib/catechism/matchers/equal.rb
+++ b/catechism/lib/catechism/matchers/equal.rb
@@ -1,6 +1,11 @@
 module Catechism
   module Matchers
     class Equal < Struct.new(:subject, :expectation, :negated)
+      def initialize(subject, expectation, negated)
+        super(subject, expectation, negated)
+        raise failure_message unless valid?
+      end
+      
       def equal?
         subject == expectation
       end

--- a/catechism/lib/catechism/matchers/raise_error.rb
+++ b/catechism/lib/catechism/matchers/raise_error.rb
@@ -1,5 +1,10 @@
 module Catechism::Matchers
   class RaiseError < Struct.new(:subject, :error_class, :negated)
+    def initialize(subject, error_class, negated)
+      super(subject, error_class, negated)
+      raise failure_message unless valid?
+    end
+    
     def raised?
       begin
         subject.call

--- a/catechism/lib/catechism/subject_wrapper.rb
+++ b/catechism/lib/catechism/subject_wrapper.rb
@@ -7,18 +7,15 @@ class Catechism::SubjectWrapper < Struct.new(:subject)
   attr_reader :negated
 
   def to_equal(expected)
-    matcher = Catechism::Matchers::Equal.new(subject, expected, negated)
-    raise matcher.failure_message unless matcher.valid?
+    Catechism::Matchers::Equal.new(subject, expected, negated)
   end
 
   def to_be_nil
-    matcher = Catechism::Matchers::Equal.new(subject, nil, negated)
-    raise matcher.failure_message unless matcher.valid?
+    Catechism::Matchers::Equal.new(subject, nil, negated)
   end
 
   def to_raise_error(error_class = StandardError)
-    matcher = Catechism::Matchers::RaiseError.new(subject, error_class, negated)
-    raise matcher.failure_message unless matcher.valid?
+    Catechism::Matchers::RaiseError.new(subject, error_class, negated)
   end
 
   def to_send(method_name)


### PR DESCRIPTION
I move the raising logic to the constructors of matchers, rather than staying in the subject_wrapper. Because when it should end matching and raise an excaption is a logic belonging to the matcher itself like the change matcher to have following calls to do and raise them then.  