### PR TITLE
Fix data aliasing issues

### DIFF
--- a/cluster/code/test/test_seed.py
+++ b/cluster/code/test/test_seed.py
@@ -32,4 +32,4 @@ class Tests(utils.ComponentTestCase):
         self.assertUnregistered()
         self.Bootstrap.assert_called_with(self.node, peers=['p1', 'p2', 'p3'],
                                           execute_fn=self.execute_fn)
-        self.Bootstrap().start.assert_called()
+        self.Bootstrap().start.assert_called_with()


### PR DESCRIPTION
This categorically addresses the unintended sharing of data structures between cluster components; #198 is one example of this issue.

Note that this makes a fresh copy of the message for each destination, avoiding aliasing either between the source and destination, or between multiple destinations.

This requires a little trickiness in Python: since we use `message` in a closure, we need a distinct variable for each destination, and we need to make that copy during the `send` invocation, not when the timer expires.