### PR TITLE
Removed the '' at the beginning of the sed command

### DIFF
--- a/_build/fix_html_title.sh
+++ b/_build/fix_html_title.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-sed -i '' 's|<p>\(title:.*\)author:\(.*\)</p>|\1\
+sed -i 's|<p>\(title:.*\)author:\(.*\)</p>|\1\
 author:\2\
 |' $1


### PR DESCRIPTION
The extra `''` at the beginning of the sed command was generating these errors:

``` bash
./_build/fix_html_title.sh html/content/pages/web-server.md

sed: can't read s|<p>\(title:.*\)author:\(.*\)</p>|\1\
author:\2\
|: No such file or directory
```

And

``` bash
ERROR: Skipping pages/web-server.md: could not find information about 'NameError: title'
```

for all `md` files
