### PR TITLE
CI: Iterate through copy of dictionary that is modified during loop

### DIFF
--- a/ci/ci.markdown
+++ b/ci/ci.markdown
@@ -457,7 +457,7 @@ will log the commit ID in the `pending_commits` variable.
 ```python
     def runner_checker(server):
         def manage_commit_lists(runner):
-            for commit, assigned_runner in server.dispatched_commits.iteritems():
+            for commit, assigned_runner in server.dispatched_commits.items():
                 if assigned_runner == runner:
                     del server.dispatched_commits[commit]
                     server.pending_commits.append(commit)

--- a/ci/code/dispatcher.py
+++ b/ci/code/dispatcher.py
@@ -123,7 +123,7 @@ def serve():
     # Create a thread to check the runner pool
     def runner_checker(server):
         def manage_commit_lists(runner):
-            for commit, assigned_runner in server.dispatched_commits.iteritems():
+            for commit, assigned_runner in server.dispatched_commits.items():
                 if assigned_runner == runner:
                     del server.dispatched_commits[commit]
                     server.pending_commits.append(commit)


### PR DESCRIPTION
The CI `dispatcher.py` modifies the dict of dispatched commits while iterating through it using `iteritems()`. This can cause a `RuntimeError` (see https://docs.python.org/2.7/library/stdtypes.html#dict.iteritems)

This trivial example demonstrates the error:

```python
d = {'a': 1, 'b': 2, 'c': 3}

for k, v in d.iteritems():
    del d[k]
```
Output:
```
Traceback (most recent call last):
  File "dict_modify.py", line 3, in <module>
    for k, v in d.iteritems():
RuntimeError: dictionary changed size during iteration
```
According to the Python docs there is a chance that it will run without error. But for me the error rate has been 100%.

Changing `iteritems()` to `items()` avoids the error.