### PR TITLE
Crawler project: fix error caused by aiohttp update that use URL object replace url str

### DIFF
--- a/crawler/code/crawling.py
+++ b/crawler/code/crawling.py
@@ -145,9 +145,9 @@ class Crawler:
                                       text))
                 if urls:
                     LOGGER.info('got %r distinct urls from %r',
-                                len(urls), response.url)
+                                len(urls), response.url.human_repr())
                 for url in urls:
-                    normalized = urllib.parse.urljoin(response.url, url)
+                    normalized = urllib.parse.urljoin(str(response.url), url)
                     defragmented, frag = urllib.parse.urldefrag(normalized)
                     if self.url_allowed(defragmented):
                         links.add(defragmented)

--- a/crawler/code/reporting.py
+++ b/crawler/code/reporting.py
@@ -29,7 +29,7 @@ def report(crawler, file=None):
     print('*** Report ***', file=file)
     try:
         show = list(crawler.done)
-        show.sort(key=lambda _stat: _stat.url)
+        show.sort(key=lambda _stat: str(_stat.url))
         for stat in show:
             url_report(stat, stats, file=file)
     except KeyboardInterrupt:


### PR DESCRIPTION
Clawler project use aiohttp version 0.21.But now aiohttp version is 2.0.7 
[Since aiohttp 1.1 the library uses yarl for URL processing, instead of url string.](http://aiohttp.readthedocs.io/en/stable/whats_new_1_1.html?highlight=URL)
That result in some str parsing errors. 

So must change code to adapt the aiohttp new version.

use URL.human_repr() to print a humanable string.
change response.url type to fix error.
Line 146 File crawling.py:
```python
                if urls:
                    LOGGER.info('got %r distinct urls from %r',
                                len(urls), response.url.human_repr())
                for url in urls:
                    normalized = urllib.parse.urljoin(str(response.url), url)
                    defragmented, frag = urllib.parse.urldefrag(normalized)
                    if self.url_allowed(defragmented):
                        links.add(defragmented)
```
change _stat.url type to fix error.
Line 32 File reporting.py
```python
show.sort(key=lambda _stat: str(_stat.url)) 
```
