### PR TITLE
Fix typo in domain subsuming

### DIFF
--- a/same-origin-policy/same-origin-policy.markdown
+++ b/same-origin-policy/same-origin-policy.markdown
@@ -622,7 +622,7 @@ that _subsumes_ others:
 
 ```alloy 
 one sig ExampleDomain extends Domain {}{
-  subsumes = EmailDomain + EvilDomain + CalendarDomain + this
+  subsumes = EmailDomain + CalendarDomain + BlogDomain + this
 }   
 ```
 


### PR DESCRIPTION
Per example.als, the BlogDomain should be part of the sub domains, not the EvilDomain