### PR TITLE
Added hint to avoid browser spellcheck

### DIFF
--- a/spreadsheet/code/as-coffeescript-1.9.0/index.html
+++ b/spreadsheet/code/as-coffeescript-1.9.0/index.html
@@ -9,7 +9,7 @@
   </tr><tr ng-repeat="row in Rows">
     <th>{{ row }}</th>
     <td ng-repeat="col in Cols" ng-class="{ formula: ( '=' === sheet[col+row][0] ) }">
-      <input id="{{ col+row }}" ng-model="sheet[col+row]" ng-change="calc()"
+      <input id="{{ col+row }}" spellcheck="false" ng-model="sheet[col+row]" ng-change="calc()"
        ng-model-options="{ debounce: 200 }" ng-keydown="keydown( $event, col, row )">
       <div ng-class="{ error: errs[col+row], text: vals[col+row][0] }">
         {{ errs[col+row] || vals[col+row] }}</div>

--- a/spreadsheet/code/as-javascript-1.8.5/index.html
+++ b/spreadsheet/code/as-javascript-1.8.5/index.html
@@ -9,7 +9,7 @@
   </tr><tr ng-repeat="row in Rows">
     <th>{{ row }}</th>
     <td ng-repeat="col in Cols" ng-class="{ formula: ( '=' === sheet[col+row][0] ) }">
-      <input id="{{ col+row }}" ng-model="sheet[col+row]" ng-change="calc()"
+      <input id="{{ col+row }}" spellcheck="false" ng-model="sheet[col+row]" ng-change="calc()"
        ng-model-options="{ debounce: 200 }" ng-keydown="keydown( $event, col, row )">
       <div ng-class="{ error: errs[col+row], text: vals[col+row][0] }">
         {{ errs[col+row] || vals[col+row] }}</div>

--- a/spreadsheet/code/as-livescript-1.3.0/index.html
+++ b/spreadsheet/code/as-livescript-1.3.0/index.html
@@ -9,7 +9,7 @@
   </tr><tr ng-repeat="row in Rows">
     <th>{{ row }}</th>
     <td ng-repeat="col in Cols" ng-class="{ formula: ( '=' === sheet[col+row][0] ) }">
-      <input id="{{ col+row }}" ng-model="sheet[col+row]" ng-change="calc()"
+      <input id="{{ col+row }}" spellcheck="false" ng-model="sheet[col+row]" ng-change="calc()"
        ng-model-options="{ debounce: 200 }" ng-keydown="keydown( $event, col, row )">
       <div ng-class="{ error: errs[col+row], text: vals[col+row][0] }">
         {{ errs[col+row] || vals[col+row] }}</div>

--- a/spreadsheet/code/as-react-livescript/main.ls
+++ b/spreadsheet/code/as-react-livescript/main.ls
@@ -55,7 +55,7 @@ Row = React.createFactory React.createClass do
 Cell = React.createFactory React.createClass displayName: \Cell render: ->
   {id, txt, err, val, onChange, onKeyDown} = @props
   td { className: if txt?0 is \= then \formula else '' },
-    input { id, type: \text, value: txt, onChange, onKeyDown }
+    input { id, spellcheck: \false, type: \text, value: txt, onChange, onKeyDown }
     div { className: if err then \error else if val?0 then \text else '' } (err || val)
 
 window.init = ->

--- a/spreadsheet/code/as-without-angularjs/main.js
+++ b/spreadsheet/code/as-without-angularjs/main.js
@@ -46,7 +46,7 @@ function Spreadsheet($scope) { init();
 
     $scope.Cols.forEach(function(col){
       var td = document.createElement( 'td' ); tr.appendChild(td);
-      var input = document.createElement( 'input' ); input.setAttribute('id', col + row);
+      var input = document.createElement( 'input' ); input.setAttribute('id', col + row); input.setAttribute('spellcheck', 'false');
       if (!((col+row) in $scope.sheet)) { $scope.sheet[col+row] = ''; }
 
       for (var event of ['change', 'input', 'paste']) { input.addEventListener(event,

--- a/spreadsheet/code/es5/index.html
+++ b/spreadsheet/code/es5/index.html
@@ -10,7 +10,7 @@
   </tr><tr ng-repeat="row in Rows">
     <th>{{ row }}</th>
     <td ng-repeat="col in Cols" ng-class="{ formula: ( '=' === sheet[col+row][0] ) }">
-      <input id="{{ col+row }}" ng-model="sheet[col+row]" ng-change="calc()"
+      <input id="{{ col+row }}" spellcheck="false" ng-model="sheet[col+row]" ng-change="calc()"
        ng-model-options="{ debounce: 200 }" ng-keydown="keydown( $event, col, row )">
       <div ng-class="{ error: errs[col+row], text: vals[col+row][0] }">
         {{ errs[col+row] || vals[col+row] }}</div>

--- a/spreadsheet/code/index.html
+++ b/spreadsheet/code/index.html
@@ -10,7 +10,7 @@
   </tr><tr ng-repeat="row in Rows">
     <th>{{ row }}</th>
     <td ng-repeat="col in Cols" ng-class="{ formula: ( '=' === sheet[col+row][0] ) }">
-      <input id="{{ col+row }}" ng-model="sheet[col+row]" ng-change="calc()"
+      <input id="{{ col+row }}" spellcheck="false" ng-model="sheet[col+row]" ng-change="calc()"
        ng-model-options="{ debounce: 200 }" ng-keydown="keydown( $event, col, row )">
       <div ng-class="{ error: errs[col+row], text: vals[col+row][0] }">
         {{ errs[col+row] || vals[col+row] }}</div>

--- a/spreadsheet/spreadsheet.markdown
+++ b/spreadsheet/spreadsheet.markdown
@@ -27,7 +27,7 @@ How many features can a web application offer in 99 lines with AngularJS? Let’
 
 ## Overview
 
-The [spreadsheet](https://github.com/audreyt/500lines/tree/master/spreadsheet/code) directory contains our showcase for late-2014 editions of the three web languages: [HTML5](http://www.w3.org/TR/html5/) for structure, [CSS3](http://www.w3.org/TR/css3-ui/) for presentation, and the JS [ES6 “Harmony”](http://git.io/es6features) standard for interaction. It also uses [web storage](http://www.whatwg.org/specs/web-apps/current-work/multipage/webstorage.html) for data persistence and [web workers](http://www.whatwg.org/specs/web-apps/current-work/multipage/workers.html) for running JS code in the background. As of this writing, these web standards are supported by Firefox, Chrome, and Internet Explorer 11+, as well as mobile browsers on iOS 5+ and Android 4+.
+The [spreadsheet](https://github.com/audreyt/500lines/tree/master/spreadsheet) directory contains our showcase for late-2014 editions of the three web languages: [HTML5](http://www.w3.org/TR/html5/) for structure, [CSS3](http://www.w3.org/TR/css3-ui/) for presentation, and the JS [ES6 “Harmony”](http://git.io/es6features) standard for interaction. It also uses [web storage](http://www.whatwg.org/specs/web-apps/current-work/multipage/webstorage.html) for data persistence and [web workers](http://www.whatwg.org/specs/web-apps/current-work/multipage/workers.html) for running JS code in the background. As of this writing, these web standards are supported by Firefox, Chrome, and Internet Explorer 11+, as well as mobile browsers on iOS 5+ and Android 4+.
 
 Now let’s open [our spreadsheet](http://audreyt.github.io/500lines/spreadsheet/) in a browser (\aosafigref{500l.spreadsheet.initial}):
 


### PR DESCRIPTION
Formulas supported by the spreadsheet may be underlined in red as though they are invalid just because the browser does not recognise them as valid words. This is an option for removing the spellcheck from the spreadsheet by adding a hint to ignore it.